### PR TITLE
Extend `::Configuration` to support dynamic attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This is an open source Ruby gem intended for developers needing to spin up a fak
 
 Clone the repo and `cd` into the project directory.
 
-```ruby
-bundle install
+```sh
+bin/setup
 ```
 
 ## Running in Development

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ You can copy that over to your own `.env` file to set these environment variable
 
 Next, to start the server, you can run:
 
-```ruby
-bundle exec rackup
+```sh
+bin/server
 ```
 
 Then navigate to `http://localhost:9292/saml/auth` to begin making your SAML requests.

--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -vx
+
+bundle exec rackup

--- a/bin/setup
+++ b/bin/setup
@@ -4,5 +4,6 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
+cp .env.example .env
 
 # Do any other automated setup that you need to do here

--- a/lib/fake_idp.rb
+++ b/lib/fake_idp.rb
@@ -18,4 +18,8 @@ module FakeIdp
   def self.configure
     yield(configuration)
   end
+
+  def self.reset!
+    @configuration = nil
+  end
 end

--- a/lib/fake_idp/application.rb
+++ b/lib/fake_idp/application.rb
@@ -10,7 +10,7 @@ module FakeIdp
         configure_cert_and_key
         @saml_response = encode_SAMLResponse(
             name_id,
-            attributes_provider: attributes_statement(signed_in_user_attrs)
+            attributes_provider: attributes_statement(user_attrs),
         )
 
         erb :auth
@@ -29,6 +29,10 @@ module FakeIdp
       self.x509_certificate = Base64.encode64(FakeIdp.configuration.idp_certificate).delete("\n")
       self.secret_key = FakeIdp.configuration.idp_secret_key
       self.algorithm = FakeIdp.configuration.algorithm
+    end
+
+    def user_attrs
+      signed_in_user_attrs.merge(FakeIdp.configuration.additional_attributes)
     end
 
     def signed_in_user_attrs

--- a/lib/fake_idp/configuration.rb
+++ b/lib/fake_idp/configuration.rb
@@ -11,6 +11,7 @@ module FakeIdp
       :idp_certificate,
       :idp_secret_key,
       :algorithm,
+      :additional_attributes,
     )
 
     def initialize
@@ -24,6 +25,7 @@ module FakeIdp
       @idp_certificate = default_idp_certificate
       @idp_secret_key = default_idp_secret_key
       @algorithm = default_algorithm
+      @additional_attributes = {}
     end
 
     private

--- a/spec/fake_idp_spec.rb
+++ b/spec/fake_idp_spec.rb
@@ -53,6 +53,12 @@ describe FakeIdp do
           FakeIdp.configure { |config| config.algorithm = :sha512 }
         end.to change { FakeIdp.configuration.algorithm }.from(:sha1).to(:sha512)
       end
+
+      it "sets the additional_attributes" do
+        expect do
+          FakeIdp.configure { |config| config.additional_attributes = { foo: "bar" } }
+        end.to change { FakeIdp.configuration.additional_attributes }.from({}).to({ foo: "bar" })
+      end
     end
   end
 end

--- a/spec/fake_idp_spec.rb
+++ b/spec/fake_idp_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe FakeIdp do
-  describe "#configure" do
+  describe ".configure" do
     context 'valid configuration' do
       before do
         FakeIdp.configure do |config|
@@ -59,6 +59,41 @@ describe FakeIdp do
           FakeIdp.configure { |config| config.additional_attributes = { foo: "bar" } }
         end.to change { FakeIdp.configuration.additional_attributes }.from({}).to({ foo: "bar" })
       end
+    end
+  end
+
+  describe ".reset!" do
+    before do
+      FakeIdp.configure do |config|
+        config.callback_url = "http://localhost.dev:3000/auth/saml/devidp/callback"
+        config.sso_uid = "12345"
+        config.username = "bobthessouser"
+        config.name_id = "bobthessouser@example.com"
+        config.additional_attributes = { foo: "bar" }
+      end
+
+      FakeIdp.reset!
+    end
+
+    it "resets the callback_url" do
+      expect(FakeIdp.configuration.callback_url).
+        not_to eq("http://localhost.dev:3000/auth/saml/devidp/callback")
+    end
+
+    it "resets the sso_uid" do
+      expect(FakeIdp.configuration.sso_uid).not_to eq("12345")
+    end
+
+    it "resets the username" do
+      expect(FakeIdp.configuration.username).not_to eq("bobthessouser")
+    end
+
+    it "resets the name_id" do
+      expect(FakeIdp.configuration.name_id).not_to eq("bobthessouser@example.com")
+    end
+
+    it "resets the additional_attributes" do
+      expect(FakeIdp.configuration.additional_attributes).not_to eq({ foo: "bar" })
     end
   end
 end


### PR DESCRIPTION
## Major Changes

### Add configuration for dynamic SAML request attributes

- We want to enable more flexibility with testing SAML requests
- Introduces `:additional_attributes` attribute to `::Configuration`
  + Defaults to an empty hash (`{}`)
  + Provides a mechanism to set a new value (tested)
  + Implemented in `::Application`
    * Implements new `#user_attrs` private method
    * Merges existing `#signed_in_user_attrs` with additional_attributes

## Misc. Changes

- Copy `.env.example` when executing `setup` command
- Adds executable for starting server
- Add `FakeIdp.reset!` method for resetting configuration
- Updates README