### PR TITLE
Update gemspec email, README, and bump to v0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,14 +9,12 @@ PATH
   remote: .
   specs:
     fake_idp (0.3.0)
-      builder
       ruby-saml-idp
       sinatra (~> 2.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    builder (3.2.3)
     diff-lcs (1.2.5)
     dotenv (1.0.2)
     macaddr (1.7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    fake_idp (0.3.0)
+    fake_idp (0.4.0)
       ruby-saml-idp
       sinatra (~> 2.0.0)
 
@@ -59,4 +59,4 @@ DEPENDENCIES
   ruby-saml-idp!
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -40,15 +40,17 @@ Then navigate to `http://localhost:9292/saml/auth` to begin making your SAML req
 
 ## Running in Test
 
-If you are using this gem to provide a Fake IDP server in a test suite, add the gem
-to the Gemfile:
+### Gemfile
+
+If you are using this gem to provide a Fake IDP server in a test suite, add the gem to the Gemfile:
 
 ```ruby
 gem 'fake_idp', github: 'healthify/fake_idp'
 ```
 
-You can set the relevant variables in a configuration block if they aren't provided 
-as environment variables. For example:
+### Configuration
+
+You can set the relevant variables in a configuration block if they aren't provided as environment variables. For example:
 
 ```ruby
 FakeIdp.configure do |config|
@@ -59,10 +61,21 @@ FakeIdp.configure do |config|
   config.idp_certificate = "YOUR CERT HERE"
   config.idp_secret_key = "YOUR KEY HERE"
   config.algorithm = :sha512
+  config.additional_attributes = { custom_saml_attr: "DELIVERED_IN_ASSERTION" }
 end
 ```
 
-And then use Capybara Discoball to spin it up in a test:
+#### Resetting Configuration
+
+If you ever want to reset your FakeIdp configuration (e.g. between test specs), you can use the following:
+
+```ruby
+FakeIdp.reset!
+```
+
+### Use
+
+You can use Capybara Discoball to spin `FakeIdp::Application` up in a test:
 
 ```ruby
 require 'fake_idp'

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -35,5 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv", "~> 1.0"
   spec.add_runtime_dependency "sinatra", "~> 2.0.0"
   spec.add_runtime_dependency "ruby-saml-idp"
-  spec.add_runtime_dependency "builder"
 end

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
     "Shelby Switzer",
     "Tyler Willingham",
     "Robyn-Dale Samuda",
+    "Chet Bortz",
   ]
   spec.email         = ["engineering@healthify.us"]
 

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
     "Tyler Willingham",
     "Robyn-Dale Samuda",
   ]
-  spec.email         = ["shelby@healthify.us"]
+  spec.email         = ["engineering@healthify.us"]
 
   spec.summary       = 'Fake IDP to test SAML authentication'
   spec.license       = "MIT"

--- a/lib/fake_idp.rb
+++ b/lib/fake_idp.rb
@@ -1,6 +1,5 @@
 require 'sinatra/base'
 require 'ruby-saml-idp'
-require 'builder'
 require 'zlib'
 require 'tilt/erb'
 require 'fake_idp/configuration'

--- a/lib/fake_idp/version.rb
+++ b/lib/fake_idp/version.rb
@@ -1,3 +1,3 @@
 module FakeIdp
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
## Changes

- Bumps version to `0.4.0`
- Update email address in gemspec
- Update README to use more headings and add note about resetting configuration