### PR TITLE
Bump gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    fake_idp (0.5.0)
+    fake_idp (0.6.0)
       activesupport (~> 5.2.4.3)
       builder (>= 3.2.2)
       nokogiri (>= 1.10.5)
@@ -31,7 +31,7 @@ GEM
     concurrent-ruby (1.1.6)
     diff-lcs (1.2.5)
     dotenv (1.0.2)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
@@ -99,4 +99,4 @@ DEPENDENCIES
   ruby-saml-idp!
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/lib/fake_idp/version.rb
+++ b/lib/fake_idp/version.rb
@@ -1,3 +1,3 @@
 module FakeIdp
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
Release created: https://github.com/healthify/fake_idp/releases/tag/0.6.0