### PR TITLE
Use ruby-saml as a runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
       activesupport (~> 5.2.4.3)
       builder (>= 3.2.2)
       nokogiri (>= 1.10.5)
+      ruby-saml (~> 1.11.0)
       ruby-saml-idp
       sinatra (~> 2.0.0)
       xmlenc (>= 0.7.1)
@@ -95,7 +96,6 @@ DEPENDENCIES
   pry (~> 0.12.2)
   rake (~> 13.0)
   rspec (~> 3.0)
-  ruby-saml (~> 1.11.0)
   ruby-saml-idp!
 
 BUNDLED WITH

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "xmlenc", ">= 0.7.1"
 
   spec.add_development_dependency "bundler", "~> 2"
-  spec.add_development_dependency "ruby-saml", "~> 1.11.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "dotenv", "~> 1.0"
@@ -44,4 +43,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "sinatra", "~> 2.0.0"
   spec.add_runtime_dependency "ruby-saml-idp"
+  spec.add_runtime_dependency "ruby-saml", "~> 1.11.0"
 end


### PR DESCRIPTION
So that the `SamlResponse` class can be publicly used by other apps and libraries we'll need to make `ruby-saml` a runtime dependency, not a dev dependency.

## Security

No security concerns since only moving a public library to the public interface in the dependency chain for use with public functionality.

## Performance

None.