### PR TITLE
Run builds against truffleruby and jruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,15 @@ rvm:
   - 2.6
   - 2.5
   - 2.4
+  - truffleruby
+  - jruby
 sudo: false
 gemfile: Gemfile
 script: bundle exec rspec spec
 before_install:
   - gem update --system 3.1.2 --no-document
   - gem install bundler -v 2.1.2 --no-document
+jobs:
+  allow_failures:
+    - rvm: truffleruby
+    - rvm: jruby


### PR DESCRIPTION
## Changes

I've added [`truffleruby`](https://github.com/oracle/truffleruby) and [`jruby`](https://github.com/jruby/jruby) to the list of builds. For both of these additions, we're allowing failures. This is an attempt to track and monitor support for these other active Ruby projects, but will not fail builds where only one or both of these options fail.

The goal primarily is to show support for other flavors of Ruby, both by indirect exposure (i.e. anyone that happens to stumble across our travis config) and adding the gem to their ecosystems of un/supported libraries.

## Test Results

Currently, our build indicates that the specs fully pass for truffleruby, but fail to run for jruby.

<img width="1063" alt="Screen Shot 2020-08-12 at 12 30 12 AM" src="https://user-images.githubusercontent.com/184307/89975222-36429f00-dc33-11ea-953a-1a8bda668a4d.png">
