### PR TITLE
Explicitly require encryption to be enabled with "true" string

### DIFF
--- a/lib/fake_idp/configuration.rb
+++ b/lib/fake_idp/configuration.rb
@@ -59,7 +59,7 @@ module FakeIdp
     end
 
     def default_encryption
-      !ENV["ENCRYPTION_ENABLED"].to_s.empty?
+      ENV["ENCRYPTION_ENABLED"] == "true"
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -7,21 +7,26 @@ describe FakeIdp::Configuration do
   end
 
   context 'when ENCRYPTION_ENABLED is set' do
-    before { ENV['ENCRYPTION_ENABLED'] = 'some_value' }
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("ENCRYPTION_ENABLED").and_return("true")
+    end
+
     it 'sets encryption_enabled to true' do
       expect(subject.encryption_enabled).to be_truthy
     end
-    after { ENV.delete('ENCRYPTION_ENABLED') }
   end
 
   context 'when ENCRYPTION_ENABLED is implicitly disabled' do
-    [nil, ''].each do |encryption_off|
-      before { ENV['ENCRYPTION_ENABLED'] = encryption_off }
+    [nil, '', 'false'].each do |encryption_off|
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("ENCRYPTION_ENABLED").and_return(encryption_off)
+      end
 
       it 'sets encryption_enabled to false' do
         expect(subject.encryption_enabled).to be_falsey
       end
-      after { ENV.delete('ENCRYPTION_ENABLED') }
     end
   end
 end


### PR DESCRIPTION
## Changes

Previously we treated /any/ value as truthy, e.g. "false". This might cause unexpected behavior. Thus, we now explicitly require the value "true" to enable encryption.