### PR TITLE
⬆️ Allow ActiveSupport versions < 7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    fake_idp (1.0.1)
+    fake_idp (1.0.2)
       activemodel (>= 5.2.5, < 7.0)
       builder (>= 3.2.2)
       nokogiri (>= 1.10.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
   remote: .
   specs:
     fake_idp (1.0.1)
-      activesupport (~> 5.2.5)
+      activemodel (>= 5.2.5, < 7.0)
       builder (>= 3.2.2)
       nokogiri (>= 1.10.5)
       ruby-saml (~> 1.11.0)
@@ -20,13 +20,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.5)
-      activesupport (= 5.2.5)
-    activesupport (5.2.5)
+    activemodel (6.1.3.1)
+      activesupport (= 6.1.3.1)
+    activesupport (6.1.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     builder (3.2.4)
     coderay (1.1.2)
     concurrent-ruby (1.1.8)
@@ -41,7 +42,7 @@ GEM
     minitest (5.14.4)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.11.2)
+    nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     pry (0.12.2)
@@ -74,10 +75,9 @@ GEM
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
     systemu (2.6.5)
-    thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     uuid (2.3.8)
       macaddr (~> 1.0)
     xmlenc (0.7.1)
@@ -87,6 +87,7 @@ GEM
       xmlmapper (>= 0.7.3)
     xmlmapper (0.7.3)
       nokogiri (~> 1.5)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "nokogiri", ">= 1.10.5"
   spec.add_dependency "builder", ">= 3.2.2"
-  spec.add_dependency "activesupport", "~> 5.2.5"
+  spec.add_dependency "activemodel", ">= 5.2.5", "< 7.0"
   spec.add_dependency "xmlenc", ">= 0.7.1"
 
   spec.add_development_dependency "bundler", "~> 2"

--- a/lib/fake_idp/version.rb
+++ b/lib/fake_idp/version.rb
@@ -1,3 +1,3 @@
 module FakeIdp
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
It appears that to prevent a CVE issue with ActiveSupport < 5.2.5 we
added `activesupport` as a direct dependency to fake_idp and made some
decisions on which version to lock to.

Because `activesupport` is only a dependency of `activemodel`, and
activemodel is itself a dependency of `xmlenc`, we can lock promote the
use of activemodel >= 5.2.5  which would thereby promote avoidance of
that previous CVE but without preventing users from using Rails 6.