### PR TITLE
⬆️ Allow ruby-saml versions <= 1.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       activemodel (>= 5.2.5, < 7.0)
       builder (>= 3.2.2)
       nokogiri (>= 1.10.5)
-      ruby-saml (~> 1.11.0)
+      ruby-saml (<= 1.12.0)
       ruby-saml-idp
       sinatra (~> 2.0.0)
       xmlenc (>= 0.7.1)
@@ -102,4 +102,4 @@ DEPENDENCIES
   ruby-saml-idp!
 
 BUNDLED WITH
-   2.1.4
+   2.2.16

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "sinatra", "~> 2.0.0"
   spec.add_runtime_dependency "ruby-saml-idp"
-  spec.add_runtime_dependency "ruby-saml", "~> 1.11.0"
+  spec.add_runtime_dependency "ruby-saml", "<= 1.12.0"
 end


### PR DESCRIPTION
Allow newer `ruby-saml` up to 1.12.0.

https://github.com/healthify/fake_idp/issues/44#issuecomment-825644935