### PR TITLE
⬆️ Allow ruby-saml versions ~> 1.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,11 @@ GIT
 PATH
   remote: .
   specs:
-    fake_idp (1.0.2)
+    fake_idp (1.0.3)
       activemodel (>= 5.2.5, < 7.0)
       builder (>= 3.2.2)
       nokogiri (>= 1.10.5)
-      ruby-saml (<= 1.12.0)
+      ruby-saml (~> 1.12)
       ruby-saml-idp
       sinatra (~> 2.0.0)
       xmlenc (>= 0.7.1)
@@ -38,7 +38,7 @@ GEM
     macaddr (1.7.1)
       systemu (~> 2.6.2)
     method_source (0.9.2)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.4)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -53,6 +53,7 @@ GEM
     rack-protection (2.0.8.1)
       rack
     rake (13.0.1)
+    rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -66,8 +67,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    ruby-saml (1.11.0)
-      nokogiri (>= 1.5.10)
+    ruby-saml (1.12.2)
+      nokogiri (>= 1.10.5)
+      rexml
     ruby2_keywords (0.0.4)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "sinatra", "~> 2.0.0"
   spec.add_runtime_dependency "ruby-saml-idp"
-  spec.add_runtime_dependency "ruby-saml", "<= 1.12.0"
+  spec.add_runtime_dependency "ruby-saml", "~> 1.12"
 end


### PR DESCRIPTION
### Problem

Perhaps inevitably, locking `ruby-saml` to `<= 1.12.0` (#48) wasn't suitable for long.

`ruby-saml` dependency `rexml` 3.2.5 fixes a security vulnerability, but we can't upgrade because `fake_idp` locks `ruby-saml` to 1.12.0 and it's fixed in `ruby-saml` 1.12.1.

### Solution

Switch to `ruby-saml ~> 1.12` which allows `>= 1.12.0` and `< 1.13.0`