### PR TITLE
Pin Nokogiri to < 1.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 PATH
   remote: .
   specs:
-    fake_idp (1.0.3)
+    fake_idp (1.0.4)
       activemodel (>= 5.2.5, < 7.0)
       builder (>= 3.2.2)
-      nokogiri (>= 1.10.5)
+      nokogiri (~> 1.11.7)
       ruby-saml (~> 1.12)
       ruby-saml-idp
       sinatra (~> 2.0.0)
@@ -20,9 +20,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3.1)
-      activesupport (= 6.1.3.1)
-    activesupport (6.1.3.1)
+    activemodel (6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -30,7 +30,7 @@ GEM
       zeitwerk (~> 2.3)
     builder (3.2.4)
     coderay (1.1.2)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.4.2)
     dotenv (1.0.2)
     i18n (1.8.10)
@@ -38,11 +38,11 @@ GEM
     macaddr (1.7.1)
       systemu (~> 2.6.2)
     method_source (0.9.2)
-    mini_portile2 (2.5.1)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.11.3)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     pry (0.12.2)
@@ -70,7 +70,7 @@ GEM
     ruby-saml (1.12.2)
       nokogiri (>= 1.10.5)
       rexml
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -87,8 +87,8 @@ GEM
       activesupport (>= 3.0.0)
       nokogiri (>= 1.6.0, < 2.0.0)
       xmlmapper (>= 0.7.3)
-    xmlmapper (0.7.3)
-      nokogiri (~> 1.5)
+    xmlmapper (0.8.1)
+      nokogiri (~> 1.11)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -104,4 +104,4 @@ DEPENDENCIES
   ruby-saml-idp!
 
 BUNDLED WITH
-   2.2.16
+   2.2.26

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", ">= 1.10.5"
+  spec.add_dependency "nokogiri", "~> 1.11.7"
   spec.add_dependency "builder", ">= 3.2.2"
   spec.add_dependency "activemodel", ">= 5.2.5", "< 7.0"
   spec.add_dependency "xmlenc", ">= 0.7.1"


### PR DESCRIPTION
[Nokogiri 1.12.x](https://github.com/sparklemotion/nokogiri/releases/tag/v1.12.0) causes errors for us when this gem uses it.

This gem doesn't pin to a Nokogiri version < 1.12, so that's what this PR does.

`nokogiri` has been changed from `>= 1.10.5` to `~> 1.11.7`.