### PR TITLE
Remove activemodel dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ PATH
   remote: .
   specs:
     fake_idp (1.0.5)
-      activemodel (>= 5.2.5, < 7.0)
       builder (>= 3.2.2)
       nokogiri (~> 1.12.5)
       ruby-saml (~> 1.13.0)

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "nokogiri", "~> 1.12.5"
   spec.add_dependency "builder", ">= 3.2.2"
-  spec.add_dependency "activemodel", ">= 5.2.5", "< 7.0"
   spec.add_dependency "xmlenc", ">= 0.7.1"
 
   spec.add_development_dependency "bundler", "~> 2"


### PR DESCRIPTION
Because it prevents using this gem with Rails 7.