### PR TITLE
Relax nokogiri versioning constraint and remove Ruby 2.5 testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ gemfile: Gemfile
 script: bundle exec rspec spec
 before_install:
   - gem update --system 3.1.2 --no-document
-  - gem install bundler -v 2.1.2 --no-document
+  - gem install bundler -v 2.3.8 --no-document
 jobs:
   allow_failures:
     - rvm: truffleruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 rvm:
   - 2.7
   - 2.6
-  - 2.5
   - truffleruby
   - jruby
 sudo: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
   specs:
     fake_idp (1.0.5)
       builder (>= 3.2.2)
-      nokogiri (~> 1.12.5)
+      nokogiri (~> 1.12)
       ruby-saml (~> 1.13.0)
       ruby-saml-idp
       sinatra (~> 2.0.0)
@@ -37,12 +37,12 @@ GEM
     macaddr (1.7.1)
       systemu (~> 2.6.2)
     method_source (0.9.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.14.4)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -103,4 +103,4 @@ DEPENDENCIES
   ruby-saml-idp!
 
 BUNDLED WITH
-   2.2.16
+   2.3.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    fake_idp (1.0.5)
+    fake_idp (1.2.0)
       builder (>= 3.2.2)
       nokogiri (~> 1.12)
       ruby-saml (~> 1.13.0)
@@ -19,9 +19,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4.1)
-      activesupport (= 6.1.4.1)
-    activesupport (6.1.4.1)
+    activemodel (6.1.4.6)
+      activesupport (= 6.1.4.6)
+    activesupport (6.1.4.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -32,13 +32,13 @@ GEM
     concurrent-ruby (1.1.9)
     diff-lcs (1.4.2)
     dotenv (1.0.2)
-    i18n (1.8.10)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
     method_source (0.9.2)
     mini_portile2 (2.8.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nokogiri (1.13.3)
@@ -88,7 +88,7 @@ GEM
       xmlmapper (>= 0.7.3)
     xmlmapper (0.8.1)
       nokogiri (~> 1.11)
-    zeitwerk (2.5.1)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby

--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "~> 1.12.5"
+  spec.add_dependency "nokogiri", "~> 1.12"
   spec.add_dependency "builder", ">= 3.2.2"
   spec.add_dependency "xmlenc", ">= 0.7.1"
 

--- a/lib/fake_idp/version.rb
+++ b/lib/fake_idp/version.rb
@@ -1,3 +1,3 @@
 module FakeIdp
-  VERSION = "1.0.5"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
I don't like that this single PR addresses 2 concerns in 1 PR but the failures in Ruby 2.5 could either be ignored or we could stop building for them. Let's save the resources since Ruby 2.5 is EOL.