### PR TITLE
Update sinatra from >= 2.0 to >= 2.2.

### DIFF
--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv", "~> 1.0"
   spec.add_development_dependency "pry", "~> 0.12.2"
 
-  spec.add_runtime_dependency "sinatra", ">= 2.0", "< 2.3"
+  spec.add_runtime_dependency "sinatra", ">= 2.2", "< 2.3"
   spec.add_runtime_dependency "ruby-saml-idp"
   spec.add_runtime_dependency "ruby-saml", "~> 1.13.0"
 end


### PR DESCRIPTION
Sinatra does not validate expanded path matches and the earliest fixed version is 2.2.0.