### PR TITLE
Update version to 1.3.0

### DIFF
--- a/lib/fake_idp/version.rb
+++ b/lib/fake_idp/version.rb
@@ -1,3 +1,3 @@
 module FakeIdp
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Upgrade the gem to 1.3.0

# Security
Upgrading the version of the gem to release a fix for a sinatra vulnerability:
>Sinatra before 2.2.0 does not validate that the expanded path matches public_dir when serving static files.

