### PR TITLE
Change ruby-saml dependency to last version

### DIFF
--- a/fake_idp.gemspec
+++ b/fake_idp.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "sinatra", ">= 2.0", "< 2.3"
   spec.add_runtime_dependency "ruby-saml-idp"
-  spec.add_runtime_dependency "ruby-saml", "~> 1.13.0"
+  spec.add_runtime_dependency "ruby-saml", "~> 1.16.0"
 end


### PR DESCRIPTION
# Why?

We need use this gem, but you have a dependency that need to update version. So, we open this PR in order to put the last version in this dependency.